### PR TITLE
Added `sbt-legacy` profile for building IDE to accomodate https://githubcom/scala-ide/scala-ide/pull/472

### DIFF
--- a/job/pr-scala-integrate-ide
+++ b/job/pr-scala-integrate-ide
@@ -321,7 +321,7 @@ MAVEN_OPTS="-Xmx2048m -XX:MaxPermSize=512m"
 cd $IDEDIR
 (test git clean -fxd) || exit 125
 # -Dtycho.disableP2Mirrors=true -- when mirrors are slow
-(test ./build-all.sh $GENMVNOPTS -DskipTests=false -Dscala.version=$SCALAVERSION-$SCALAHASH-SNAPSHOT -Pscala-$SCALASHORT.x -Peclipse-juno clean install) | tee -a $LOGGINGDIR/compilation-$SCALADATE-$SCALAHASH.log
+(test ./build-all.sh $GENMVNOPTS -Psbt-legacy -DskipTests=false -Dscala.version=$SCALAVERSION-$SCALAHASH-SNAPSHOT -Pscala-$SCALASHORT.x -Peclipse-juno clean install) | tee -a $LOGGINGDIR/compilation-$SCALADATE-$SCALAHASH.log
 ide_return=${PIPESTATUS[0]}
 if [ $ide_return -ne 0 ]; then
     say "### SCALA-IDE FAILED !"


### PR DESCRIPTION
This PR should be merged at the exact same time of https://github.com/scala-ide/scala-ide/pull/472, or the Scala/IDE script will start failing to build.
