### PR TITLE
Pass additional profile to IDE build to ignore known flaky tests

### DIFF
--- a/job/pr-scala-integrate-ide
+++ b/job/pr-scala-integrate-ide
@@ -321,7 +321,7 @@ MAVEN_OPTS="-Xmx2048m -XX:MaxPermSize=512m"
 cd $IDEDIR
 (test git clean -fxd) || exit 125
 # -Dtycho.disableP2Mirrors=true -- when mirrors are slow
-(test ./build-all.sh $GENMVNOPTS -Psbt-legacy -DskipTests=false -Dscala.version=$SCALAVERSION-$SCALAHASH-SNAPSHOT -Pscala-$SCALASHORT.x -Peclipse-juno clean install) | tee -a $LOGGINGDIR/compilation-$SCALADATE-$SCALAHASH.log
+(test ./build-all.sh $GENMVNOPTS -Psbt-legacy -PskipFlakyTests -DskipTests=false -Dscala.version=$SCALAVERSION-$SCALAHASH-SNAPSHOT -Pscala-$SCALASHORT.x -Peclipse-juno clean install) | tee -a $LOGGINGDIR/compilation-$SCALADATE-$SCALAHASH.log
 ide_return=${PIPESTATUS[0]}
 if [ $ide_return -ne 0 ]; then
     say "### SCALA-IDE FAILED !"


### PR DESCRIPTION
By passing the additional maven profile `skipFlakyTests`, tests that are known
to be flacky are ignored.

You can merge this PR at your earliest convenience. The additional profile will be simply ignored until https://github.com/scala-ide/scala-ide/pull/498 is merged. Hopefully, from now on all failures will be authentic.
