### PR TITLE
Revert "Added `sbt-legacy` profile for building IDE to accomodate

### DIFF
--- a/job/pr-scala-integrate-ide
+++ b/job/pr-scala-integrate-ide
@@ -177,7 +177,7 @@ set -e
 cd $IDEDIR
 (test git clean -fxd) || exit 125
 # -Dtycho.disableP2Mirrors=true -- when mirrors are slow
-(test ./build-all.sh $GENMVNOPTS -Psbt-new -PretryFlakyTests -DskipTests=false -Dscala.version=$SCALA_MAVEN_VERSION -Pscala-$SCALASHORT.x -Peclipse-juno clean install) | tee -a $LOGGINGDIR/compilation-$SCALADATE-$SCALAHASH.log
+(test ./build-all.sh $GENMVNOPTS -PretryFlakyTests -DskipTests=false -Dscala.version=$SCALA_MAVEN_VERSION -Pscala-$SCALASHORT.x -Peclipse-juno clean install) | tee -a $LOGGINGDIR/compilation-$SCALADATE-$SCALAHASH.log
 ide_return=${PIPESTATUS[0]}
 if [ $ide_return -ne 0 ]; then
     say "### SCALA-IDE FAILED !"


### PR DESCRIPTION
https://github.com/scala-ide/scala-ide/pull/472"

This reverts commit ed56efa9123f216fe050b1f284dd85fef7e0a3e7.

The maven `sbt-new` profile that was introduced by SHA:
fa2740d6c9c35196169466c285c0d51257f36488 no longer needs to be passed because,
as of now, that is the default working mode of the Scala IDE build
(https://github.com/scala-ide/scala-ide/pull/548).
