### PR TITLE
Use build.number rather than build.number.maven

### DIFF
--- a/job/scala-nightly-pdf-doc
+++ b/job/scala-nightly-pdf-doc
@@ -28,7 +28,7 @@ cd ../scala-dist/documentation
 
 cat >build.properties <<'TheProps'
 scala.starr.dir=../../scala
-number.file=../../scala/build.number.maven
+number.file=../../scala/build.number
 intro.excludes=**/coercions.*
 TheProps
 echo "Building pdf files..."


### PR DESCRIPTION
Adapting to https://github.com/scala/scala/commit/1e8e16e1
