### PR TITLE
Disable publish of spores nightlies.

### DIFF
--- a/job/spores-2103/run
+++ b/job/spores-2103/run
@@ -39,5 +39,5 @@ cd "$script_dir/scala/test"
 SCALAC_OPTS="-Xplugin:$plugin" ./partest --all
 
 # STEP 4: PUBLISH TO SONATYPE
-cd "$script_dir/spores-plugin"
-runSbt "project spores" publish
+# cd "$script_dir/spores-plugin"
+# runSbt "project spores" publish


### PR DESCRIPTION
We haven't decided on the group-id yet, and this is failing in nightly builds.
