### PR TITLE
pr-scala-integrate-partest now actually uses the distrib being tested

### DIFF
--- a/job/pr-scala-integrate-partest
+++ b/job/pr-scala-integrate-partest
@@ -64,7 +64,7 @@ curl -o $BASEDIR/sbt-launch.jar -s http://repo.typesafe.com/typesafe/ivy-release
 SBT_JAVA_OPTS="-XX:MaxPermSize=384m -Xmx4096M -XX:+CMSClassUnloadingEnabled -XX:ReservedCodeCacheSize=256m -Dsbt.global.base=$SBT_HOME -Dsbt.ivy.home=$IVY_CACHE -Dsbt.log.noformat=true -jar $BASEDIR/sbt-launch.jar"
 
 (cd $PARTESTDIR &&
- java $SBT_JAVA_OPTS "reboot full" clean "set every scalaVersion := \"$SCALAVERSION-$SCALAHASH-SNAPSHOT\"" "show scala-instance" publish-local)
+ java $SBT_JAVA_OPTS "reboot full" clean "set every scalaHome := Some(file(\"$SCALADIR/build/pack\"))" "show scala-instance" publish-local)
 
 # Remove .sbt/repositories scaffolding
 #cleanupsbt


### PR DESCRIPTION
Apparently, it's not enough to set scalaVersion to point to the synthetic
version of the distrib that's just been built and published to maven.

It looks that regardless of the value of scalaVersion that's being set,
sbt is going to use the compiler provided in build.sbt of scala-partest.

I was quite surprised to see that, but I made sure that it's the stale
compiler that causes the problem. I put a random println in the new
compiler, build it, published it and ran a local equivalent of
pr-scala-integrate-partest. Unfortunately, I never saw the funny println
I introduced.

Therefore I propose to switch gears and use scalaHome instead of scalaVersion.
