### PR TITLE
Succeed if $sha does not exist (and reduce noise).

### DIFF
--- a/job/pr-scala-per-commit
+++ b/job/pr-scala-per-commit
@@ -22,9 +22,12 @@ then
   [[ -f $WORKSPACE/mergetarget ]] || (git rev-parse FETCH_HEAD > $WORKSPACE/mergetarget)
   git checkout --detach -f $mergetarget
   git clean -fxd
-  git merge $sha
-  echo "Building commit $sha of #${pullrequest} (merged into ${mergebranch})."
-  (cd $WORKSPACE/ && ./jenkins-scripts/job/$JOB_NAME)
+  if (git merge $sha); then
+      echo "Building commit $sha of #${pullrequest} (merged into ${mergebranch})."
+      (cd $WORKSPACE/ && ./jenkins-scripts/job/$JOB_NAME)
+  else
+      echo "Merge failed for ${sha}. push --force on ${pullrequest}?. Succeeding trivially"
+  fi
 else # build intermediate commits as-is
   echo "Building $sha unless already merged into a (master-like) branch in the repository."
   git fetch origin


### PR DESCRIPTION
I don't know if anyone else experiences this, but we're receiving email notifications for every IDE validation failure. A lot of them are spurious (see blow, probably force-pushing on the PR before the validation script got the chance to start). This is my attempt to reduce noise.

```
From github.com:scala/scala
 * branch            master     -> FETCH_HEAD
++ [[ -f <https://scala-webapps.epfl.ch/jenkins/job/pr-scala-integrate-ide/ws/mergetarget> ]]
++ git checkout --detach -f 8848f241616627b0c5beca38a5107c4eca3e10fd
HEAD is now at 8848f24... Merge pull request #3007 from densh/pull/fresh-name-and-package-support
++ git clean -fxd
++ git merge 50f30dcf52a6fb8f1db4487e524ef0c78a6eef64
fatal: '50f30dcf52a6fb8f1db4487e524ef0c78a6eef64' does not point to a commit
Build step 'Execute shell' marked build as failure
```
