### PR TITLE
Revert "temporarily disables scala/scala tests for push a new build of paradise 2.11"

### DIFF
--- a/job/macro-paradise-2110/run
+++ b/job/macro-paradise-2110/run
@@ -19,25 +19,25 @@ runSbt "project tests" test
 plugin=( $(pwd)/plugin/target/scala-2.11.0-SNAPSHOT/macro-paradise_*.jar )
 [[ ! -f "$plugin" ]] && exit 1
 
-# # STEP 3: SELECT SCALAC BRANCH AND APPLY OUR PATCHES
-# # TODO: make all the tests pass
-# # current failures are quite minor, but it's still annoying
-# cd "$script_dir/scala"
-# git checkout master
-# git apply "$script_dir/test_fixup.patch"
+# STEP 3: SELECT SCALAC BRANCH AND APPLY OUR PATCHES
+# TODO: make all the tests pass
+# current failures are quite minor, but it's still annoying
+cd "$script_dir/scala"
+git checkout master
+git apply "$script_dir/test_fixup.patch"
 
-# # STEP 4: BOOTSTRAP SCALAC USING THE PARADISE PLUGIN
-# cd "$script_dir/scala"
-# ./pull-binary-libs.sh
-# ant locker.done # we might be binary incompatible with starr, so no plugin when building locker
-# # TODO: don't know what's going on, but with the plugin enabled Universe.reify stops being recognized as a macro
-# # well, I actually I have a suspicion that hijacking fastTrack might lead to Universe.reify not being marked as MACRO
-# # but I've disabled the hijack when compiling scala-reflect.jar, and the problem still persists
-# # ant "-Dscalac.args=\"-Xplugin:$plugin\"" build-opt test.bc
-# ant build partest.task
-# # TODO: make all the tests pass
-# # current failures are quite minor, but it's still annoying
-# ant "-Dscalac.args.optimise=\"-Xplugin:$plugin\"" test.suite
+# STEP 4: BOOTSTRAP SCALAC USING THE PARADISE PLUGIN
+cd "$script_dir/scala"
+./pull-binary-libs.sh
+ant locker.done # we might be binary incompatible with starr, so no plugin when building locker
+# TODO: don't know what's going on, but with the plugin enabled Universe.reify stops being recognized as a macro
+# well, I actually I have a suspicion that hijacking fastTrack might lead to Universe.reify not being marked as MACRO
+# but I've disabled the hijack when compiling scala-reflect.jar, and the problem still persists
+# ant "-Dscalac.args=\"-Xplugin:$plugin\"" build-opt test.bc
+ant build partest.task
+# TODO: make all the tests pass
+# current failures are quite minor, but it's still annoying
+ant "-Dscalac.args.optimise=\"-Xplugin:$plugin\"" test.suite
 
 # STEP 4: PUBLISH TO SONATYPE
 cd "$script_dir/paradise"


### PR DESCRIPTION
Now when paradise 2.11 no longer produces an AME, I can take my time to fix the breakage of the changeset that patches several partests failing for paradise 2.11.
