### PR TITLE
scala-nightly-main publishes to maven (only on master)

### DIFF
--- a/job/scala-nightly-main
+++ b/job/scala-nightly-main
@@ -1,8 +1,17 @@
 #!/bin/bash -x
 
+savedState=0
+savedStatePublish=0
+
 scriptsDir="$( cd "$( dirname "$0" )/.." && pwd )"
 
 $scriptsDir/build
 savedState=$?
+
+if grep -q '<target name="publish"' build.xml; then
+  ant publish
+  savedStatePublish=$?
+fi
+
 $scriptsDir/archive-nightly
-exit $savedState
+exit $(($savedState || $savedStatePublish))

--- a/publish-nightly
+++ b/publish-nightly
@@ -36,8 +36,8 @@ EOM
     rsync -az build/scaladoc/ "$nightly_rsync_dest/$scaladocDir"
 
     # push to the maven repository
-    # if there's no build.xml, we've already published during the main job (we're on master aka 2.11.x)
-    if [[ -f dists/maven/latest/build.xml ]]; then
+    # in master, we've already published during the main job
+    if [[ "$jobName" != *-master ]]; then
       cd dists/maven/latest
       ant deploy -Dsettings.file=$maven_settings_file
     fi


### PR DESCRIPTION
The publish-nightly job still rsyncs artifacts and publishes to maven for older versions.

/cc @retronym
