### PR TITLE
Remove the default for build parameter SCALA_VER_SUFFIX

### DIFF
--- a/job/scala-release-2.11.x
+++ b/job/scala-release-2.11.x
@@ -27,8 +27,8 @@
 # TODO: introduce SCALA_BINARY_VER and use it in -Dscala.binary.version=$SCALA_BINARY_VER
 
 # defaults for jenkins params
+# but, no default for SCALA_VER_SUFFIX, "" is a valid value for the final release.
       SCALA_VER_BASE=${SCALA_VER_BASE-"2.11.0"}
-    SCALA_VER_SUFFIX=${SCALA_VER_SUFFIX-"-RC1"}
              XML_VER=${XML_VER-"1.0.0"}
          PARSERS_VER=${PARSERS_VER-"1.0.0"}
    CONTINUATIONS_VER=${CONTINUATIONS_VER-"1.0.0"}


### PR DESCRIPTION
As the empty string is a a valid value.

I checked if this variable is used in other builds in the same way.
It is only used in this job:

```
% ack SCALA_VER_SUFFIX
job/scala-release-2.11.x
30:# but, no default for SCALA_VER_SUFFIX, "" is a valid value for the final release.
80:SCALA_VER="$SCALA_VER_BASE$SCALA_VER_SUFFIX"
272:    -Dmaven.version.suffix=$SCALA_VER_SUFFIX\
321:#     -Dmaven.version.suffix=$SCALA_VER_SUFFIX\
```
