### PR TITLE
Add new parameter to release job: SCALA_BINARY_VER

### DIFF
--- a/job/scala-release-2.11.x
+++ b/job/scala-release-2.11.x
@@ -195,7 +195,7 @@ publishModulesPrivate() {
   update rickynils scalacheck $SCALACHECK_REF
   $sbtCmd $sbtArgs 'set version := "'$SCALACHECK_VER'"' \
       'set scalaVersion := "'$SCALA_VER'"' \
-      'set every scalaBinaryVersion := "'$SCALA_VER'"' \
+      'set every scalaBinaryVersion := "'$SCALA_BINARY_VER'"' \
       'set VersionKeys.scalaParserCombinatorsVersion := "'$PARSERS_VER'"' \
       "set publishTo := Some($resolver)"\
       'set credentials += Credentials(Path.userHome / ".ivy2" / ".credentials-private-repo")'\


### PR DESCRIPTION
Otherwise, the build for privately published build of Scalacheck
[fails](https://scala-webapps.epfl.ch/jenkins/view/scala-release-2.11.x/job/scala-release-2.11.x/54/console) for binary-compatible releases (ie, non-RCs) with:

```
unresolved dependency: org.scala-lang.modules#scala-parser-combinators_2.11.0;1.0.1: not found
```
