### PR TITLE
Allow use of JDK8 with older Ants.

### DIFF
--- a/job/scala-nightly-auxjvm
+++ b/job/scala-nightly-auxjvm
@@ -2,4 +2,7 @@
 
 scriptsDir="$( cd "$( dirname "$0" )/.." && pwd )"
 
-antArgs="-Darchives.skipxz=true" $scriptsDir/build
+# Needed on older Ants with JDK8, see https://netbeans.org/bugzilla/show_bug.cgi?id=213403
+(java -version 2>&1 | grep "1\.8\.") && setBuildCompiler=-Dbuild.compiler=javac1.7
+
+antArgs="-Darchives.skipxz=true $setBuildCompiler" $scriptsDir/build


### PR DESCRIPTION
See:

  http://stackoverflow.com/questions/23442621/ant-class-not-found-javac1-8
  https://netbeans.org/bugzilla/show_bug.cgi?id=213403
