### PR TITLE
fix links to source in scaladoc for nightly builds

### DIFF
--- a/job/scala-release-2.11.x
+++ b/job/scala-release-2.11.x
@@ -319,6 +319,8 @@ determineScalaVersion() {
       parseScalaProperties "build.number"
       SCALA_VER_BASE="$version_major.$version_minor.$version_patch"
       SCALA_VER_SUFFIX="-$(git rev-parse --short HEAD)-nightly"
+      SCALA_DOC_VER=$(git rev-parse HEAD)
+
       # TODO: publish nightly snapshot using this script
       publishToSonatype="no"
       echo "dist_ref=2.11.x" >> $baseDir/jenkins.properties # for the -dist downstream jobs that build the actual archives
@@ -328,6 +330,7 @@ determineScalaVersion() {
       local RE='v*\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)\([0-9A-Za-z-]*\)' # don't change this to make it more accurate, it's not worth it
       SCALA_VER_BASE="$(echo $scalaTag | sed -e "s#$RE#\1.\2.\3#")"
       SCALA_VER_SUFFIX="$(echo $scalaTag | sed -e "s#$RE#\4#")"
+      SCALA_DOC_VER=$scalaTag
 
       if [ "$SCALA_VER_BASE" == "$scalaTag" ]; then
         echo "Could not parse version $scalaTag"
@@ -495,6 +498,7 @@ bootstrap() {
       -Dmaven.version.suffix=$SCALA_VER_SUFFIX\
       ${updatedModuleVersions[@]} \
       -Dupdate.versions=1\
+      -Dscaladoc.git.commit=$SCALA_DOC_VER\
       -Dremote.snapshot.repository=NOPE\
       -Dremote.release.repository=$privateRepo\
       -Drepository.credentials.id=$privateCred\


### PR DESCRIPTION
The ant build assumes that providing `maven.version.suffix` means we are
building a release, and ends up using the scala version in
link-to-source urls. For nightly builds this means in the library
scaladoc we get github urls that are wrong, like
https://github.com/scala/scala/tree/v2.11.2-73fb460-nightly/src/library/scala/Predef.scala#L1.

See http://www.scala-lang.org/files/archive/nightly/2.11.x/api/2.11.2-73fb460-nightly/#scala.Predef$
for an example.

This just makes the script pass to ant the correct value: either the
scala tag of the release, or the full commit of the current HEAD.
