### PR TITLE
removes -no-share from sbt invocations in macro builds

### DIFF
--- a/job/macro-paradise-2102/run
+++ b/job/macro-paradise-2102/run
@@ -5,7 +5,7 @@ script_dir="$( cd "$( dirname "$0" )" && pwd )"
 scriptsDir="$( cd "$( dirname "$0" )/../.." && pwd )"
 . $scriptsDir/common
 runSbt () {
-  sbt -Dmaven.settings.file="$maven_settings_file" -no-colors -no-share -sbt-launch-dir "$script_dir/project/launcher" "$@"
+  sbt -Dmaven.settings.file="$maven_settings_file" -no-colors -sbt-launch-dir "$script_dir/project/launcher" "$@"
 }
 git clean -dfx
 if [[ -d paradise ]]; then rm -rf paradise; fi

--- a/job/macro-paradise-2103/run
+++ b/job/macro-paradise-2103/run
@@ -5,7 +5,7 @@ script_dir="$( cd "$( dirname "$0" )" && pwd )"
 scriptsDir="$( cd "$( dirname "$0" )/../.." && pwd )"
 . $scriptsDir/common
 runSbt () {
-  sbt -Dmaven.settings.file="$maven_settings_file" -no-colors -no-share -sbt-launch-dir "$script_dir/project/launcher" "$@"
+  sbt -Dmaven.settings.file="$maven_settings_file" -no-colors -sbt-launch-dir "$script_dir/project/launcher" "$@"
 }
 git clean -dfx
 if [[ -d paradise ]]; then rm -rf paradise; fi

--- a/job/macro-paradise-2104/run
+++ b/job/macro-paradise-2104/run
@@ -5,7 +5,7 @@ script_dir="$( cd "$( dirname "$0" )" && pwd )"
 scriptsDir="$( cd "$( dirname "$0" )/../.." && pwd )"
 . $scriptsDir/common
 runSbt () {
-  sbt -Dmaven.settings.file="$maven_settings_file" -no-colors -no-share -sbt-launch-dir "$script_dir/project/launcher" "$@"
+  sbt -Dmaven.settings.file="$maven_settings_file" -no-colors -sbt-launch-dir "$script_dir/project/launcher" "$@"
 }
 git clean -dfx
 if [[ -d paradise ]]; then rm -rf paradise; fi

--- a/job/macro-paradise-210x/run
+++ b/job/macro-paradise-210x/run
@@ -5,7 +5,7 @@ script_dir="$( cd "$( dirname "$0" )" && pwd )"
 scriptsDir="$( cd "$( dirname "$0" )/../.." && pwd )"
 . $scriptsDir/common
 runSbt () {
-  sbt -Dmaven.settings.file="$maven_settings_file" -no-colors -no-share -sbt-launch-dir "$script_dir/project/launcher" "$@"
+  sbt -Dmaven.settings.file="$maven_settings_file" -no-colors -sbt-launch-dir "$script_dir/project/launcher" "$@"
 }
 git clean -dfx
 if [[ -d paradise ]]; then rm -rf paradise; fi

--- a/job/macro-paradise-2110/run
+++ b/job/macro-paradise-2110/run
@@ -5,7 +5,7 @@ script_dir="$( cd "$( dirname "$0" )" && pwd )"
 scriptsDir="$( cd "$( dirname "$0" )/../.." && pwd )"
 . $scriptsDir/common
 runSbt () {
-  sbt -Dmaven.settings.file="$maven_settings_file" -no-colors -no-share -sbt-launch-dir "$script_dir/project/launcher" "$@"
+  sbt -Dmaven.settings.file="$maven_settings_file" -no-colors -sbt-launch-dir "$script_dir/project/launcher" "$@"
 }
 git clean -dfx
 if [[ -d paradise ]]; then rm -rf paradise; fi

--- a/job/macro-paradise-2111/run
+++ b/job/macro-paradise-2111/run
@@ -5,7 +5,7 @@ script_dir="$( cd "$( dirname "$0" )" && pwd )"
 scriptsDir="$( cd "$( dirname "$0" )/../.." && pwd )"
 . $scriptsDir/common
 runSbt () {
-  sbt -Dmaven.settings.file="$maven_settings_file" -no-colors -no-share -sbt-launch-dir "$script_dir/project/launcher" "$@"
+  sbt -Dmaven.settings.file="$maven_settings_file" -no-colors -sbt-launch-dir "$script_dir/project/launcher" "$@"
 }
 git clean -dfx
 if [[ -d paradise ]]; then rm -rf paradise; fi

--- a/job/macro-paradise-2112/run
+++ b/job/macro-paradise-2112/run
@@ -5,7 +5,7 @@ script_dir="$( cd "$( dirname "$0" )" && pwd )"
 scriptsDir="$( cd "$( dirname "$0" )/../.." && pwd )"
 . $scriptsDir/common
 runSbt () {
-  sbt -Dmaven.settings.file="$maven_settings_file" -no-colors -no-share -sbt-launch-dir "$script_dir/project/launcher" "$@"
+  sbt -Dmaven.settings.file="$maven_settings_file" -no-colors -sbt-launch-dir "$script_dir/project/launcher" "$@"
 }
 git clean -dfx
 if [[ -d paradise ]]; then rm -rf paradise; fi

--- a/job/macro-paradise-211x/run
+++ b/job/macro-paradise-211x/run
@@ -5,7 +5,7 @@ script_dir="$( cd "$( dirname "$0" )" && pwd )"
 scriptsDir="$( cd "$( dirname "$0" )/../.." && pwd )"
 . $scriptsDir/common
 runSbt () {
-  sbt -Dmaven.settings.file="$maven_settings_file" -no-colors -no-share -sbt-launch-dir "$script_dir/project/launcher" "$@"
+  sbt -Dmaven.settings.file="$maven_settings_file" -no-colors -sbt-launch-dir "$script_dir/project/launcher" "$@"
 }
 git clean -dfx
 if [[ -d paradise ]]; then rm -rf paradise; fi

--- a/job/macro-paradise-212x/run
+++ b/job/macro-paradise-212x/run
@@ -5,7 +5,7 @@ script_dir="$( cd "$( dirname "$0" )" && pwd )"
 scriptsDir="$( cd "$( dirname "$0" )/../.." && pwd )"
 . $scriptsDir/common
 runSbt () {
-  sbt -Dmaven.settings.file="$maven_settings_file" -no-colors -no-share -sbt-launch-dir "$script_dir/project/launcher" "$@"
+  sbt -Dmaven.settings.file="$maven_settings_file" -no-colors -sbt-launch-dir "$script_dir/project/launcher" "$@"
 }
 git clean -dfx
 if [[ -d paradise ]]; then rm -rf paradise; fi

--- a/job/run-macro-sbt-on-macro-paradise/run
+++ b/job/run-macro-sbt-on-macro-paradise/run
@@ -3,7 +3,7 @@
 script_dir="$( cd "$( dirname "$0" )" && pwd )"
 
 runSbt () {
-  sbt -no-colors -no-share -sbt-launch-dir $script_dir/project/launcher "$@"
+  sbt -no-colors -sbt-launch-dir $script_dir/project/launcher "$@"
 }
 
 verify () {

--- a/job/run-macro-sbt-on-scala/run
+++ b/job/run-macro-sbt-on-scala/run
@@ -3,7 +3,7 @@
 script_dir="$( cd "$( dirname "$0" )" && pwd )"
 
 runSbt () {
-  sbt -no-colors -no-share -sbt-launch-dir $script_dir/project/launcher "$@"
+  sbt -no-colors -sbt-launch-dir $script_dir/project/launcher "$@"
 }
 
 verify () {


### PR DESCRIPTION
I found that this sometimes leads to spurious failures like, which
disappear when I remove -no-share.

sbt.InvalidScalaInstance: Scala instance doesn't exist or is invalid:
    version 2.10.4, library jar: /localhome/jenkins/c/workspace/macro-paradise-nightly-2.10.x/job/macro-paradise-210x/paradise/project/.ivy/cache/org.scala-lang/scala-library/jars/scala-library-2.10.4.jar, compiler jar: /localhome/jenkins/c/workspace/macro-paradise-nightly-2.10.x/job/macro-paradise-210x/paradise/project/.ivy/cache/org.scala-lang/scala-compiler/jars/scala-compiler-2.10.4.jar
(E.g. see https://scala-webapps.epfl.ch/jenkins/view/misc/job/macro-paradise-nightly-2.10.x/474/console)

The errors started appearing when I committed
https://github.com/scalamacros/paradise/commit/d1284c776cac657b91a2e63f59bdbd8fd7dba50b,
where I set Scala version to 2.10.4 in a subproject of a big project
that uses Scala version 2.10.x.
