### PR TITLE
Read versions.properties from the checkout

### DIFF
--- a/job/pr-scala-test-tmp
+++ b/job/pr-scala-test-tmp
@@ -17,9 +17,8 @@ scriptsDir="$( cd "$( dirname "$0" )/.." && pwd )"
 . $scriptsDir/common
 . $scriptsDir/pr-scala-common
 
-parse_properties versions.properties
-
 cd $WORKSPACE/scala
+parse_properties versions.properties
 
 ./pull-binary-libs.sh || ./pull-binary-libs
 


### PR DESCRIPTION
Given that artifacts are not copied, we don't have versions.properties
prepared for us anymore.
